### PR TITLE
Add project-ops commands: edit, comment, comments, status, link

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,29 @@ bjira setpass
 ~ » bjira view                    # Открыть задачку в браузере, имя задачки взять из ветки гит-репозитория
 
 ```
+
+### Project-ops commands (fork extension)
+
+```shell script
+~ » bjira edit PORTFOLIO-53307 --due 2026-05-15                         # set Due Date
+~ » bjira edit PORTFOLIO-53307 --description-file ./spec.md --force     # overwrite description from file
+~ » bjira edit PORTFOLIO-53307 --label urgent --label q2-2026           # merge labels with existing
+~ » bjira edit PORTFOLIO-53307 --labels-clear                           # remove all labels
+~ » bjira edit PORTFOLIO-53307 --assignee i.moltyaninov                 # reassign
+~ » bjira edit PORTFOLIO-53307 --assignee none                          # unassign
+
+~ » bjira comment PORTFOLIO-53307 "готово, ждём ревью"                  # add comment
+~ » bjira comment PORTFOLIO-53307 --from-file ./update.md               # add comment from file
+
+~ » bjira comments PORTFOLIO-53307                                      # list last 5 comments
+~ » bjira comments PORTFOLIO-53307 -n 20                                # list last 20
+
+~ » bjira status PORTFOLIO-53307 "Development: In progress"             # transition (fuzzy match)
+~ » bjira status PORTFOLIO-53307 1501                                   # transition by id
+
+~ » bjira link PORTFOLIO-53307 Blocks PORTFOLIO-54000                   # link existing issues
+```
+
+**Exit codes:** `0` success, `2` arg error, `3` API error (auth/permission/not-found, ambiguous/unknown match). Pass `-v` for SDK debug logging.
+
+**Safety:** `--force` is required for `edit --description` and `edit --summary` when the existing value is non-empty. All other operations are additive or trivially reversible via Jira history.

--- a/bjira/_fields.py
+++ b/bjira/_fields.py
@@ -1,0 +1,19 @@
+def merge_labels(existing, add, clear):
+    """Return the final label list after merge, or None if no API change needed.
+
+    - clear=True  → wipe existing first, then add
+    - clear=False → union of existing + add, preserving existing order
+    - If result equals existing, return None to signal no-op.
+    """
+    if clear:
+        result = []
+        for label in add:
+            if label not in result:
+                result.append(label)
+        return result if result != existing else None
+
+    result = list(existing)
+    for label in add:
+        if label not in result:
+            result.append(label)
+    return result if result != existing else None

--- a/bjira/_fields.py
+++ b/bjira/_fields.py
@@ -1,3 +1,6 @@
+import datetime
+
+
 def merge_labels(existing, add, clear):
     """Return the final label list after merge, or None if no API change needed.
 
@@ -17,3 +20,16 @@ def merge_labels(existing, add, clear):
         if label not in result:
             result.append(label)
     return result if result != existing else None
+
+
+def parse_due(value):
+    """Return ISO date string, or None to clear. Raise ValueError on invalid input."""
+    if value == "none":
+        return None
+    if not value:
+        raise ValueError("due must be YYYY-MM-DD or 'none'")
+    try:
+        datetime.date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"due must be YYYY-MM-DD or 'none', got {value!r}") from exc
+    return value

--- a/bjira/_fields.py
+++ b/bjira/_fields.py
@@ -33,3 +33,21 @@ def parse_due(value):
     except ValueError as exc:
         raise ValueError(f"due must be YYYY-MM-DD or 'none', got {value!r}") from exc
     return value
+
+
+_FORCE_GATED_FIELDS = {"summary", "description"}
+
+
+def should_require_force(field, current, force):
+    """Return True if this edit needs --force but force was not passed.
+
+    Only 'summary' and 'description' are gated: they are free-form, potentially long,
+    and a typo'd overwrite is painful. Whitespace-only existing values count as empty.
+    """
+    if force:
+        return False
+    if field not in _FORCE_GATED_FIELDS:
+        return False
+    if not current or not current.strip():
+        return False
+    return True

--- a/bjira/_match.py
+++ b/bjira/_match.py
@@ -1,0 +1,45 @@
+class AmbiguousMatch(ValueError):
+    pass
+
+
+class NoMatch(ValueError):
+    pass
+
+
+def match_transition(query, transitions):
+    """Resolve a user query to a transition id.
+
+    Match order: numeric id -> case-insensitive exact name -> case-insensitive substring.
+    Ambiguous substring matches raise AmbiguousMatch with candidate list.
+    """
+    if query.isdigit():
+        for t in transitions:
+            if t["id"] == query:
+                return t["id"]
+        raise NoMatch(f"no transition with id={query}")
+
+    q = query.lower()
+    exact = [t for t in transitions if t["name"].lower() == q]
+    if len(exact) == 1:
+        return exact[0]["id"]
+
+    # Substring matching: check if all words in query appear in the name (in order)
+    query_words = q.split()
+    def matches_query_words(name):
+        name_lower = name.lower()
+        pos = 0
+        for word in query_words:
+            pos = name_lower.find(word, pos)
+            if pos == -1:
+                return False
+            pos += len(word)
+        return True
+
+    substr = [t for t in transitions if matches_query_words(t["name"])]
+    if len(substr) == 1:
+        return substr[0]["id"]
+    if len(substr) > 1:
+        candidates = ", ".join(f"{t['id']} {t['name']}" for t in substr)
+        raise AmbiguousMatch(f"ambiguous (matches {len(substr)}: {candidates})")
+
+    raise NoMatch(f"no transition matches {query!r}")

--- a/bjira/_match.py
+++ b/bjira/_match.py
@@ -43,3 +43,13 @@ def match_transition(query, transitions):
         raise AmbiguousMatch(f"ambiguous (matches {len(substr)}: {candidates})")
 
     raise NoMatch(f"no transition matches {query!r}")
+
+
+def resolve_link_type(query, link_types):
+    """Return canonical link type name (case-insensitive exact match)."""
+    q = query.lower()
+    for lt in link_types:
+        if lt["name"].lower() == q:
+            return lt["name"]
+    available = ", ".join(lt["name"] for lt in link_types)
+    raise NoMatch(f"unknown link type {query!r}; available: {available}")

--- a/bjira/_text.py
+++ b/bjira/_text.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+def resolve_body_source(positional, from_file):
+    """Pick exactly one source and return the body text."""
+    if positional is not None and from_file:
+        raise ValueError("positional body and --from-file are mutually exclusive")
+    if positional is not None:
+        if positional == "":
+            raise ValueError("body is empty")
+        return positional
+    if from_file:
+        try:
+            return Path(from_file).read_text()
+        except OSError as exc:
+            raise ValueError(f"cannot read {from_file}: {exc}") from exc
+    raise ValueError("body is required: pass as positional arg or --from-file PATH")
+
+
+def format_comment(c):
+    """Format a jira.Comment or dict-like into the display form from spec."""
+    created = c["created"] if isinstance(c, dict) else c.created
+    author = (c["author"]["displayName"] if isinstance(c, dict) else c.author.displayName)
+    body = c["body"] if isinstance(c, dict) else c.body
+    cid = c["id"] if isinstance(c, dict) else c.id
+    # created like "2026-04-23T20:59:12.000+0300" → "2026-04-23 20:59"
+    date_part, time_part = created.split("T")
+    hhmm = time_part[:5]
+    header = f"[{date_part} {hhmm}] {author} (id={cid}):"
+    return f"{header}\n{body}\n---\n"

--- a/bjira/main.py
+++ b/bjira/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import logging
 from importlib import import_module
 from pkgutil import walk_packages
 
@@ -8,6 +9,8 @@ import bjira.operations
 
 def _parse_args():
     parser = argparse.ArgumentParser(description='jira helper')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='print HTTP calls and payloads to stderr')
     subparsers = parser.add_subparsers(help='sub-command help', required=True)
 
     for module_info in walk_packages(bjira.operations.__path__, bjira.operations.__name__ + '.'):
@@ -18,6 +21,9 @@ def _parse_args():
 
 def main():
     args = _parse_args()
+    if getattr(args, 'verbose', False):
+        logging.basicConfig(level=logging.DEBUG)
+        logging.getLogger('urllib3').setLevel(logging.WARNING)
     args.func(args)
 
 

--- a/bjira/operations/comment.py
+++ b/bjira/operations/comment.py
@@ -1,0 +1,35 @@
+import sys
+
+from jira import JIRAError
+
+from bjira.operations import BJiraOperation
+from bjira._text import resolve_body_source
+
+
+class Operation(BJiraOperation):
+
+    def configure_arg_parser(self, subparsers):
+        parser = subparsers.add_parser("comment", help="add a comment to an issue")
+        parser.add_argument("key", help="issue key, e.g. PORTFOLIO-53307")
+        parser.add_argument("body", nargs="?", default=None, help="comment body")
+        parser.add_argument("--from-file", dest="from_file", default=None,
+                            help="read body from file")
+        parser.set_defaults(func=self._run)
+
+    def _run(self, args):
+        try:
+            body = resolve_body_source(args.body, args.from_file)
+        except ValueError as exc:
+            print(f"ERROR: comment {args.key}: {exc}", file=sys.stderr)
+            sys.exit(2)
+
+        jira = self.get_jira_api()
+        try:
+            comment = jira.add_comment(args.key, body)
+        except JIRAError as exc:
+            print(f"ERROR: comment {args.key}: {exc.status_code} {exc.text}",
+                  file=sys.stderr)
+            sys.exit(3)
+
+        host = self.get_config()["host"]
+        print(f"comment id={comment.id} url={host}/browse/{args.key}?focusedCommentId={comment.id}")

--- a/bjira/operations/comments.py
+++ b/bjira/operations/comments.py
@@ -1,0 +1,29 @@
+import sys
+
+from jira import JIRAError
+
+from bjira.operations import BJiraOperation
+from bjira._text import format_comment
+
+
+class Operation(BJiraOperation):
+
+    def configure_arg_parser(self, subparsers):
+        parser = subparsers.add_parser("comments", help="list recent comments")
+        parser.add_argument("key", help="issue key")
+        parser.add_argument("-n", dest="count", type=int, default=5,
+                            help="how many newest comments to show (default 5)")
+        parser.set_defaults(func=self._run)
+
+    def _run(self, args):
+        jira = self.get_jira_api()
+        try:
+            all_comments = jira.comments(args.key)
+        except JIRAError as exc:
+            print(f"ERROR: comments {args.key}: {exc.status_code} {exc.text}",
+                  file=sys.stderr)
+            sys.exit(3)
+
+        recent = list(reversed(all_comments))[:args.count]
+        for c in recent:
+            sys.stdout.write(format_comment(c))

--- a/bjira/operations/edit.py
+++ b/bjira/operations/edit.py
@@ -1,0 +1,128 @@
+import sys
+
+from jira import JIRAError
+
+from bjira.operations import BJiraOperation
+from bjira._fields import merge_labels, parse_due, should_require_force
+from bjira._text import resolve_body_source
+
+
+STORY_POINTS_FIELD = "customfield_11212"
+
+
+class Operation(BJiraOperation):
+
+    def configure_arg_parser(self, subparsers):
+        parser = subparsers.add_parser("edit", help="edit fields on an issue")
+        parser.add_argument("key", help="issue key")
+        parser.add_argument("--summary", default=None)
+        parser.add_argument("--description", default=None)
+        parser.add_argument("--description-file", dest="description_file", default=None)
+        parser.add_argument("--due", default=None, help="YYYY-MM-DD or 'none' to clear")
+        parser.add_argument("--assignee", default=None, help="login or 'none' to unassign")
+        parser.add_argument("--label", dest="labels", action="append", default=[],
+                            help="repeatable; merged with existing")
+        parser.add_argument("--labels-clear", dest="labels_clear", action="store_true")
+        parser.add_argument("--sp", dest="story_points", type=float, default=None)
+        parser.add_argument("--force", action="store_true",
+                            help="allow overwriting non-empty summary/description")
+        parser.set_defaults(func=self._run)
+
+    def _run(self, args):
+        if args.description is not None and args.description_file is not None:
+            self._fail_args("--description and --description-file are mutually exclusive")
+
+        wants_any = any([
+            args.summary is not None,
+            args.description is not None,
+            args.description_file is not None,
+            args.due is not None,
+            args.assignee is not None,
+            args.labels,
+            args.labels_clear,
+            args.story_points is not None,
+        ])
+        if not wants_any:
+            self._fail_args("nothing to update; pass at least one of "
+                            "--summary/--description/--description-file/--due/"
+                            "--assignee/--label/--labels-clear/--sp")
+
+        if args.description_file is not None:
+            try:
+                description = resolve_body_source(None, args.description_file)
+            except ValueError as exc:
+                self._fail_args(str(exc))
+        else:
+            description = args.description
+
+        due_payload_set = False
+        due_value = None
+        if args.due is not None:
+            try:
+                due_value = parse_due(args.due)
+            except ValueError as exc:
+                self._fail_args(str(exc))
+            due_payload_set = True
+
+        jira = self.get_jira_api()
+        try:
+            issue = jira.issue(args.key, fields="summary,description,labels")
+        except JIRAError as exc:
+            self._fail_api(args.key, exc)
+
+        summary_changes = (args.summary is not None
+                           and args.summary != (issue.fields.summary or ""))
+        description_changes = (description is not None
+                               and description != (issue.fields.description or ""))
+
+        if summary_changes and should_require_force(
+                "summary", issue.fields.summary or "", args.force):
+            self._fail_args(
+                f"existing summary is not empty ({len(issue.fields.summary)} chars); "
+                "pass --force to overwrite")
+        if description_changes and should_require_force(
+                "description", issue.fields.description or "", args.force):
+            self._fail_args(
+                f"existing description is not empty ({len(issue.fields.description)} chars); "
+                "pass --force to overwrite")
+
+        fields = {}
+        if summary_changes:
+            fields["summary"] = args.summary
+        if description_changes:
+            fields["description"] = description
+        if due_payload_set:
+            fields["duedate"] = due_value
+        if args.assignee is not None:
+            fields["assignee"] = None if args.assignee == "none" else {"name": args.assignee}
+        if args.labels or args.labels_clear:
+            merged = merge_labels(list(issue.fields.labels or []), args.labels, args.labels_clear)
+            if merged is not None:
+                fields["labels"] = merged
+        if args.story_points is not None:
+            fields[STORY_POINTS_FIELD] = args.story_points
+
+        if not fields:
+            print(f"{args.key}: no changes")
+            return
+
+        try:
+            issue.update(fields=fields)
+        except JIRAError as exc:
+            self._fail_api(args.key, exc)
+
+        parts = []
+        for k, v in fields.items():
+            if k == "description":
+                parts.append(f"description=<{len(v)} chars>" if v else "description=cleared")
+            else:
+                parts.append(f"{k}={v}")
+        print(f"OK: {args.key} {', '.join(parts)}")
+
+    def _fail_args(self, msg):
+        print(f"ERROR: edit: {msg}", file=sys.stderr)
+        sys.exit(2)
+
+    def _fail_api(self, key, exc):
+        print(f"ERROR: edit {key}: {exc.status_code} {exc.text}", file=sys.stderr)
+        sys.exit(3)

--- a/bjira/operations/link.py
+++ b/bjira/operations/link.py
@@ -1,0 +1,43 @@
+import sys
+
+from jira import JIRAError
+
+from bjira.operations import BJiraOperation
+from bjira._match import resolve_link_type, NoMatch
+
+
+class Operation(BJiraOperation):
+
+    def configure_arg_parser(self, subparsers):
+        parser = subparsers.add_parser("link", help="link two existing issues")
+        parser.add_argument("from_key", help="source issue key")
+        parser.add_argument("link_type", help="link type name, e.g. Blocks")
+        parser.add_argument("to_key", help="target issue key")
+        parser.set_defaults(func=self._run)
+
+    def _run(self, args):
+        jira = self.get_jira_api()
+        try:
+            link_types = [
+                {"name": lt.name, "inward": lt.inward, "outward": lt.outward}
+                for lt in jira.issue_link_types()
+            ]
+        except JIRAError as exc:
+            print(f"ERROR: link: {exc.status_code} {exc.text}", file=sys.stderr)
+            sys.exit(3)
+
+        try:
+            canonical = resolve_link_type(args.link_type, link_types)
+        except NoMatch as exc:
+            print(f"ERROR: link: {exc}", file=sys.stderr)
+            sys.exit(3)
+
+        outward_verb = next(lt["outward"] for lt in link_types if lt["name"] == canonical)
+
+        try:
+            jira.create_issue_link(canonical, inwardIssue=args.to_key, outwardIssue=args.from_key)
+        except JIRAError as exc:
+            print(f"ERROR: link: {exc.status_code} {exc.text}", file=sys.stderr)
+            sys.exit(3)
+
+        print(f"{args.from_key} {outward_verb} {args.to_key}")

--- a/bjira/operations/status.py
+++ b/bjira/operations/status.py
@@ -1,0 +1,43 @@
+import sys
+
+from jira import JIRAError
+
+from bjira.operations import BJiraOperation
+from bjira._match import match_transition, AmbiguousMatch, NoMatch
+
+
+class Operation(BJiraOperation):
+
+    def configure_arg_parser(self, subparsers):
+        parser = subparsers.add_parser("status", help="transition an issue")
+        parser.add_argument("key", help="issue key")
+        parser.add_argument("transition", help="transition id, name, or substring")
+        parser.set_defaults(func=self._run)
+
+    def _run(self, args):
+        jira = self.get_jira_api()
+        try:
+            transitions = jira.transitions(args.key)
+            issue = jira.issue(args.key, fields="status")
+        except JIRAError as exc:
+            print(f"ERROR: status {args.key}: {exc.status_code} {exc.text}",
+                  file=sys.stderr)
+            sys.exit(3)
+
+        try:
+            tid = match_transition(args.transition, transitions)
+        except (AmbiguousMatch, NoMatch) as exc:
+            print(f"ERROR: status {args.key} {args.transition!r}: {exc}",
+                  file=sys.stderr)
+            sys.exit(3)
+
+        old_status = issue.fields.status.name
+        try:
+            jira.transition_issue(args.key, tid)
+        except JIRAError as exc:
+            print(f"ERROR: status {args.key}: {exc.status_code} {exc.text}",
+                  file=sys.stderr)
+            sys.exit(3)
+
+        new_issue = jira.issue(args.key, fields="status")
+        print(f"{args.key}: {old_status} → {new_issue.fields.status.name}")

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -1,0 +1,61 @@
+"""Live smoke test against jira.hh.ru. Run manually after substantial changes.
+
+Usage: ~/.local/pipx/venvs/bjira/bin/python tests/smoke.py
+"""
+import json
+import subprocess
+from pathlib import Path
+
+import keyring
+from jira import JIRA
+
+CONFIG = json.loads((Path.home() / ".bjira_config").read_text())
+USER = CONFIG["user"]
+HOST = CONFIG["host"]
+ISSUE = "PORTFOLIO-53307"
+
+jira = JIRA(server=HOST, basic_auth=(USER, keyring.get_password("bjira", USER)))
+
+
+def run(cmd):
+    print(f"$ {' '.join(cmd)}")
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    print(r.stdout)
+    if r.returncode != 0:
+        print(f"  stderr: {r.stderr}")
+    return r
+
+
+def main():
+    print("=== 1. comments (read) ===")
+    r = run(["bjira", "comments", ISSUE, "-n", "1"])
+    assert r.returncode == 0, "comments read failed"
+
+    print("\n=== 2. comment add → delete ===")
+    r = run(["bjira", "comment", ISSUE, "[SMOKE] test — auto-delete"])
+    assert r.returncode == 0, "comment add failed"
+    cid = r.stdout.split("id=")[1].split()[0]
+    jira.comment(ISSUE, cid).delete()
+    print(f"  deleted comment {cid}")
+
+    print("\n=== 3. edit --summary <same> (no-op) ===")
+    current = jira.issue(ISSUE, fields="summary").fields.summary
+    r = run(["bjira", "edit", ISSUE, "--summary", current])
+    assert r.returncode == 0, "no-op summary failed"
+    assert "no changes" in r.stdout, f"expected 'no changes' in output, got: {r.stdout!r}"
+
+    print("\n=== 4. status — unknown transition check ===")
+    r = run(["bjira", "status", ISSUE, "nonexistent"])
+    assert r.returncode == 3, f"expected exit 3, got {r.returncode}"
+    print("  correctly returned exit 3 for unknown transition")
+
+    print("\n=== 5. link — unknown type check ===")
+    r = run(["bjira", "link", ISSUE, "NotARealType", ISSUE])
+    assert r.returncode == 3, f"expected exit 3, got {r.returncode}"
+    print("  correctly returned exit 3 for unknown link type")
+
+    print("\n=== all smoke checks passed ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bjira._fields import merge_labels, parse_due
+from bjira._fields import merge_labels, parse_due, should_require_force
 
 
 def test_merge_labels_adds_new():
@@ -48,3 +48,29 @@ def test_parse_due_rejects_empty():
 def test_parse_due_rejects_bad_calendar_date():
     with pytest.raises(ValueError):
         parse_due("2026-13-40")
+
+
+def test_force_required_when_description_nonempty_and_no_force():
+    assert should_require_force("description", current="old body", force=False) is True
+
+
+def test_force_not_required_when_description_empty():
+    assert should_require_force("description", current="", force=False) is False
+
+
+def test_force_not_required_when_description_whitespace_only():
+    assert should_require_force("description", current="   \n\n  ", force=False) is False
+
+
+def test_force_not_required_when_force_passed():
+    assert should_require_force("description", current="old body", force=True) is False
+
+
+def test_force_required_when_summary_nonempty_and_no_force():
+    assert should_require_force("summary", current="old title", force=False) is True
+
+
+def test_force_not_required_for_other_fields():
+    assert should_require_force("duedate", current="2026-01-01", force=False) is False
+    assert should_require_force("labels", current=["a"], force=False) is False
+    assert should_require_force("assignee", current="someone", force=False) is False

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,6 @@
-from bjira._fields import merge_labels
+import pytest
+
+from bjira._fields import merge_labels, parse_due
 
 
 def test_merge_labels_adds_new():
@@ -23,3 +25,26 @@ def test_merge_labels_returns_none_when_no_change():
 
 def test_merge_labels_preserves_existing_order():
     assert merge_labels(existing=["z", "a", "m"], add=["b"], clear=False) == ["z", "a", "m", "b"]
+
+
+def test_parse_due_valid_date():
+    assert parse_due("2026-05-15") == "2026-05-15"
+
+
+def test_parse_due_none_keyword_returns_none_string():
+    assert parse_due("none") is None
+
+
+def test_parse_due_rejects_invalid_format():
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        parse_due("15/05/2026")
+
+
+def test_parse_due_rejects_empty():
+    with pytest.raises(ValueError):
+        parse_due("")
+
+
+def test_parse_due_rejects_bad_calendar_date():
+    with pytest.raises(ValueError):
+        parse_due("2026-13-40")

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,25 @@
+from bjira._fields import merge_labels
+
+
+def test_merge_labels_adds_new():
+    assert merge_labels(existing=["a", "b"], add=["c"], clear=False) == ["a", "b", "c"]
+
+
+def test_merge_labels_ignores_duplicates():
+    assert merge_labels(existing=["a", "b"], add=["a", "c"], clear=False) == ["a", "b", "c"]
+
+
+def test_merge_labels_clear_wipes_then_adds():
+    assert merge_labels(existing=["a", "b"], add=["x"], clear=True) == ["x"]
+
+
+def test_merge_labels_clear_only():
+    assert merge_labels(existing=["a", "b"], add=[], clear=True) == []
+
+
+def test_merge_labels_returns_none_when_no_change():
+    assert merge_labels(existing=["a", "b"], add=["a"], clear=False) is None
+
+
+def test_merge_labels_preserves_existing_order():
+    assert merge_labels(existing=["z", "a", "m"], add=["b"], clear=False) == ["z", "a", "m", "b"]

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,0 +1,48 @@
+import pytest
+from bjira._match import match_transition, AmbiguousMatch, NoMatch
+
+
+TRANSITIONS = [
+    {"id": "1421", "name": "Backlog"},
+    {"id": "1501", "name": "Development: In progress"},
+    {"id": "1511", "name": "Development: Done"},
+    {"id": "1481", "name": "Decomposition: In progress"},
+    {"id": "1381", "name": "Fixed"},
+]
+
+
+def test_match_by_exact_numeric_id():
+    assert match_transition("1501", TRANSITIONS) == "1501"
+
+
+def test_match_by_exact_name():
+    assert match_transition("Development: In progress", TRANSITIONS) == "1501"
+
+
+def test_match_by_case_insensitive_substring():
+    assert match_transition("dev in pro", TRANSITIONS) == "1501"
+
+
+def test_match_case_insensitive_exact():
+    assert match_transition("fixed", TRANSITIONS) == "1381"
+
+
+def test_ambiguous_substring_raises():
+    with pytest.raises(AmbiguousMatch) as exc:
+        match_transition("development", TRANSITIONS)
+    assert "1501" in str(exc.value)
+    assert "1511" in str(exc.value)
+
+
+def test_no_match_raises():
+    with pytest.raises(NoMatch):
+        match_transition("totallynotathing", TRANSITIONS)
+
+
+def test_exact_name_wins_over_substring():
+    assert match_transition("Backlog", TRANSITIONS) == "1421"
+
+
+def test_numeric_id_not_in_list_raises():
+    with pytest.raises(NoMatch):
+        match_transition("9999", TRANSITIONS)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,5 +1,5 @@
 import pytest
-from bjira._match import match_transition, AmbiguousMatch, NoMatch
+from bjira._match import match_transition, resolve_link_type, AmbiguousMatch, NoMatch
 
 
 TRANSITIONS = [
@@ -46,3 +46,25 @@ def test_exact_name_wins_over_substring():
 def test_numeric_id_not_in_list_raises():
     with pytest.raises(NoMatch):
         match_transition("9999", TRANSITIONS)
+
+
+LINK_TYPES = [
+    {"name": "Blocks", "inward": "blocked by", "outward": "blocks"},
+    {"name": "Relates", "inward": "relates to", "outward": "relates to"},
+    {"name": "Duplicate", "inward": "is duplicated by", "outward": "duplicates"},
+]
+
+
+def test_resolve_link_type_exact():
+    assert resolve_link_type("Blocks", LINK_TYPES) == "Blocks"
+
+
+def test_resolve_link_type_case_insensitive():
+    assert resolve_link_type("blocks", LINK_TYPES) == "Blocks"
+    assert resolve_link_type("BLOCKS", LINK_TYPES) == "Blocks"
+
+
+def test_resolve_link_type_unknown_raises():
+    with pytest.raises(NoMatch) as exc:
+        resolve_link_type("notarealtype", LINK_TYPES)
+    assert "Blocks" in str(exc.value)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,47 @@
+import pytest
+from bjira._text import resolve_body_source, format_comment
+
+
+def test_resolve_body_from_positional(tmp_path):
+    assert resolve_body_source(positional="hi there", from_file=None) == "hi there"
+
+
+def test_resolve_body_from_file(tmp_path):
+    p = tmp_path / "body.md"
+    p.write_text("file body\nline 2")
+    assert resolve_body_source(positional=None, from_file=str(p)) == "file body\nline 2"
+
+
+def test_resolve_body_rejects_both_sources():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        resolve_body_source(positional="x", from_file="/tmp/x")
+
+
+def test_resolve_body_rejects_neither_source():
+    with pytest.raises(ValueError, match="required"):
+        resolve_body_source(positional=None, from_file=None)
+
+
+def test_resolve_body_rejects_empty_positional():
+    with pytest.raises(ValueError, match="empty"):
+        resolve_body_source(positional="", from_file=None)
+
+
+def test_resolve_body_rejects_missing_file():
+    with pytest.raises(ValueError, match="cannot read"):
+        resolve_body_source(positional=None, from_file="/no/such/path.md")
+
+
+def test_format_comment_basic():
+    c = {
+        "id": "11506156",
+        "created": "2026-04-23T20:59:12.000+0300",
+        "author": {"displayName": "Молтянинов Илья"},
+        "body": "test body",
+    }
+    out = format_comment(c)
+    assert "[2026-04-23 20:59]" in out
+    assert "Молтянинов Илья" in out
+    assert "(id=11506156)" in out
+    assert "test body" in out
+    assert out.endswith("---\n") or out.endswith("---")


### PR DESCRIPTION
## Summary

Adds five new subcommands to cover routine Jira project management directly from the terminal — editing fields, reading/adding comments, transitioning status, and linking existing issues.

| Command | Purpose |
|---|---|
| `bjira edit KEY --summary/--description[-file]/--due/--assignee/--label/--labels-clear/--sp [--force]` | Edit any of the common fields on an issue |
| `bjira comment KEY "text"` / `--from-file PATH` | Add a comment (body as arg or file) |
| `bjira comments KEY [-n N]` | List the N newest comments (default 5) |
| `bjira status KEY TRANSITION` | Transition — accepts id, exact name, or case-insensitive word-subsequence match (`"dev in"` → `"Development: In progress"`) |
| `bjira link FROM TYPE TO` | Link two existing issues (case-insensitive type match) |

Plus global `-v/--verbose` that enables SDK debug logging (useful for "why did that API call fail?" debugging).

## Design notes

- **Uses the existing `walk_packages` auto-discovery** in `main.py` — each new command is a drop-in file in `bjira/operations/`, zero changes to main.py required. Only `-v` flag addition touches main.py.
- **Pure helpers extracted to `bjira/_fields.py`, `bjira/_match.py`, `bjira/_text.py`** so 80%+ of logic can be unit-tested without network or SDK mocks.
- **Exit codes are stable**: `0` success, `2` arg error, `3` API/validation error.
- **Safety via `--force` gate on `edit --description` and `edit --summary`** — and only these — when existing value is non-empty. Free-form fields get the gate because accidental overwrites of long markdown are painful; other fields (due, labels, assignee, etc.) are visible in the command itself, so no gate needed. Everything is still reversible via Jira's issue history.

## Testing

- `tests/test_fields.py`, `tests/test_match.py`, `tests/test_text.py` — **35 unit tests, zero network, <0.1s run**. Cover label merging (set semantics + clear), due parsing, force gate, transition matching (id/exact/subsequence), link type resolution, body source resolution (arg vs file vs invalid), and comment formatting.
- `tests/smoke.py` — live smoke against `jira.hh.ru` for all 5 commands with auto-cleanup. Run manually before release.

Run unit tests:
```
pytest tests/ --ignore=tests/smoke.py
```

## Test plan

- [x] `pytest tests/` — 35 passed
- [x] `python tests/smoke.py` — all 5 checks passed on `PORTFOLIO-53307`
- [x] `bjira --help` lists all old + new commands
- [x] `bjira comment` / `comments` / `status` / `link` / `edit` each verified live on a sandbox issue
- [x] `--force` gate verified to fire on non-empty description and be bypassable
- [x] No-op updates (e.g. `edit --summary <same>`) short-circuit without API call
- [x] `bjira -v` prints SDK debug logs to stderr